### PR TITLE
feat: rename package to opencode-skills-collection

### DIFF
--- a/.github/workflows/deprecate-legacy-package.yml
+++ b/.github/workflows/deprecate-legacy-package.yml
@@ -1,0 +1,56 @@
+name: Deprecate Legacy Package
+
+# Run this workflow ONCE after publishing opencode-skills-collection to npm.
+# It publishes a final stub of opencode-skills-antigravity that re-exports
+# opencode-skills-collection, then marks it as deprecated on npm.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deprecate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Create stub package
+        run: |
+          mkdir stub
+          cat > stub/package.json << 'EOF'
+          {
+            "name": "opencode-skills-antigravity",
+            "version": "99.0.0",
+            "description": "⚠️ Deprecated: renamed to opencode-skills-collection",
+            "main": "index.js",
+            "dependencies": {
+              "opencode-skills-collection": "latest"
+            },
+            "repository": {
+              "type": "git",
+              "url": "https://github.com/FrancoStino/opencode-skills-collection"
+            },
+            "license": "MIT"
+          }
+          EOF
+          cat > stub/index.js << 'EOF'
+          module.exports = require('opencode-skills-collection');
+          EOF
+
+      - name: Publish stub to npm
+        working-directory: stub
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Deprecate legacy package on npm
+        run: npm deprecate opencode-skills-antigravity "⚠️ Package renamed to opencode-skills-collection. Please update your plugin config: https://github.com/FrancoStino/opencode-skills-collection"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deprecate-legacy-package.yml
+++ b/.github/workflows/deprecate-legacy-package.yml
@@ -21,13 +21,22 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Resolve next stub version
+        id: version
+        run: |
+          CURRENT=$(npm view opencode-skills-antigravity version 2>/dev/null || echo "0.0.0")
+          NEXT=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number); console.log(a+'.'+b+'.'+(c+1))" $CURRENT)
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Create stub package
         run: |
           mkdir stub
-          cat > stub/package.json << 'EOF'
+          cat > stub/package.json << EOF
           {
             "name": "opencode-skills-antigravity",
-            "version": "99.0.0",
+            "version": "${{ steps.version.outputs.next }}",
             "description": "⚠️ Deprecated: renamed to opencode-skills-collection",
             "main": "index.js",
             "dependencies": {

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Configure git

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 <div align="center">
 
-<img src="./docs/logo.svg" alt="OpenCode Skills Antigravity"/>
+<img src="./docs/logo.svg" alt="OpenCode Skills Collection"/>
 
 <br/>
 <br/>
 <br/>
 
-[![npm version](https://img.shields.io/npm/v/opencode-skills-antigravity?style=for-the-badge&color=cb3837&label=npm)](https://www.npmjs.com/package/opencode-skills-antigravity)
-[![npm downloads](https://img.shields.io/npm/dm/opencode-skills-antigravity?style=for-the-badge&color=orange)](https://www.npmjs.com/package/opencode-skills-antigravity)
-[![license](https://img.shields.io/github/license/FrancoStino/opencode-skills-antigravity?style=for-the-badge&color=blue)](./LICENSE)
+[![npm version](https://img.shields.io/npm/v/opencode-skills-collection?style=for-the-badge&color=cb3837&label=npm)](https://www.npmjs.com/package/opencode-skills-collection)
+[![npm downloads](https://img.shields.io/npm/dm/opencode-skills-collection?style=for-the-badge&color=orange)](https://www.npmjs.com/package/opencode-skills-collection)
+[![license](https://img.shields.io/github/license/FrancoStino/opencode-skills-collection?style=for-the-badge&color=blue)](./LICENSE)
 
 </div>
 
-# OpenCode Skills Antigravity
+# OpenCode Skills Collection
 
 > An [OpenCode CLI](https://opencode.ai/) plugin that bundles and auto-syncs the [Antigravity Awesome Skills](https://github.com/sickn33/antigravity-awesome-skills) collection — delivered instantly, with zero network latency at startup.
+
+> ⚠️ **Previously published as [`opencode-skills-antigravity`](https://www.npmjs.com/package/opencode-skills-antigravity)** — that package is now deprecated and points to this one.
 
 ---
 
 ## Overview
 
-**OpenCode Skills Antigravity** bridges the OpenCode CLI with the Antigravity Awesome Skills repository. Instead of fetching skills on every startup, this plugin ships with a pre-bundled snapshot that gets copied directly to your local machine the moment OpenCode launches.
+**OpenCode Skills Collection** bridges the OpenCode CLI with the Antigravity Awesome Skills repository. Instead of fetching skills on every startup, this plugin ships with a pre-bundled snapshot that gets copied directly to your local machine the moment OpenCode launches.
 
 The result: skills are always fresh (synced hourly via GitHub Actions), always available (even offline), and always instant.
 
@@ -58,7 +60,7 @@ Add the plugin to your global OpenCode configuration file at `~/.config/opencode
 ```json
 {
   "plugin": [
-    "opencode-skills-antigravity"
+    "opencode-skills-collection"
   ]
 }
 ```
@@ -95,7 +97,7 @@ opencode run /refactor clean up this function
 ## Project Structure
 
 ```
-opencode-skills-antigravity/
+opencode-skills-collection/
 ├── src/
 │   └── index.ts          # Plugin entry point — copies bundled skills on startup
 ├── bundled-skills/        # Pre-bundled skills snapshot (auto-updated by CI)
@@ -130,9 +132,25 @@ The plugin is written in TypeScript and compiled to ESNext with full type declar
 
 ---
 
+## Migration from `opencode-skills-antigravity`
+
+If you were using the old package, simply update your `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "plugin": [
+    "opencode-skills-collection"
+  ]
+}
+```
+
+The old `opencode-skills-antigravity` package on npm is deprecated and re-exports this one automatically.
+
+---
+
 ## Contributing
 
-Issues and pull requests are welcome at [github.com/FrancoStino/opencode-skills-antigravity](https://github.com/FrancoStino/opencode-skills-antigravity/issues).
+Issues and pull requests are welcome at [github.com/FrancoStino/opencode-skills-collection](https://github.com/FrancoStino/opencode-skills-collection/issues).
 
 If you'd like to contribute new skills to the upstream collection, head over to [antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills) — they'll be automatically picked up and bundled here within the hour.
 

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -22,7 +22,7 @@
   <text x="76" y="68"
     font-family="'Geist', 'Inter', 'Segoe UI', sans-serif"
     font-size="13" font-weight="400" fill="#aaaaaa" letter-spacing="1.5">
-    SKILLS ANTIGRAVITY
+    SKILLS COLLECTION
   </text>
 
   <!-- Linea separatore accent -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "opencode-skills-antigravity",
+  "name": "opencode-skills-collection",
   "version": "1.0.116",
-  "description": "OpenCode CLI plugin that automatically downloads and keeps Antigravity Awesome Skills up to date.",
+  "description": "OpenCode CLI plugin that automatically downloads and keeps skills up to date.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -10,11 +10,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FrancoStino/opencode-skills-antigravity"
+    "url": "https://github.com/FrancoStino/opencode-skills-collection"
   },
-  "homepage": "https://github.com/FrancoStino/opencode-skills-antigravity",
+  "homepage": "https://github.com/FrancoStino/opencode-skills-collection",
   "bugs": {
-    "url": "https://github.com/FrancoStino/opencode-skills-antigravity/issues"
+    "url": "https://github.com/FrancoStino/opencode-skills-collection/issues"
   },
   "scripts": {
     "build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import path from "path";
 import os from "os";
 import { fileURLToPath } from "url";
 
-const AntigravityAutoUpdater: Plugin = async (_ctx) => {
+const OpenCodeSkillsCollection: Plugin = async (_ctx) => {
   try {
     // Resolve absolute path to the bundled-skills directory relative to this file
     // Works regardless of where OpenCode is launched from
@@ -34,4 +34,4 @@ const AntigravityAutoUpdater: Plugin = async (_ctx) => {
   return {};
 };
 
-export default AntigravityAutoUpdater;
+export default OpenCodeSkillsCollection;


### PR DESCRIPTION
## 📦 Package Rename: `opencode-skills-antigravity` → `opencode-skills-collection`

This PR renames the project to **`opencode-skills-collection`** for a more generic and future-proof name, decoupled from the upstream "Antigravity" branding.

### Changes

- **`package.json`** — updated `name`, `description`, `repository`, `homepage`, `bugs` URLs
- **`README.md`** — updated all references, badges, and install instructions to the new name; added migration note and deprecation notice

### Post-merge steps (manual)

- [x] Rename the GitHub repository to `opencode-skills-collection` (Settings → Repository name)
- [x] Publish `opencode-skills-collection` to npm
- [x] Publish a stub `opencode-skills-antigravity` package pointing to the new one as fallback:
  ```bash
  npm deprecate opencode-skills-antigravity "⚠️ Package renamed to opencode-skills-collection. Please update your plugin config."
  ```
