### PR TITLE
feat: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill in the details below.
+
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Pre-filing checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is.
+      placeholder: "When I do X, I expect Y, but Z happens."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Load skill '...'
+        2. Run command '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Plugin Version
+      description: "Output of `opencode --version` or check package.json"
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Paste any relevant error messages or logs.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Anything else — OS, environment, screenshots, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Report
+    url: https://github.com/FrancoStino/opencode-skills-collection/issues/new?template=bug-report.yml
+    about: Report a bug or unexpected behavior
+  - name: Security Disclosure
+    url: https://github.com/FrancoStino/opencode-skills-collection/blob/main/SECURITY.md
+    about: For security issues, follow responsible disclosure policy. Do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/skill-addition.yml
+++ b/.github/ISSUE_TEMPLATE/skill-addition.yml
@@ -1,0 +1,115 @@
+name: Skill Addition Request
+description: Request a new skill to be added to the collection
+title: "[Skill] "
+labels: ["skill-request", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Request a New Skill
+
+        Before submitting, please:
+        - Search [existing issues](https://github.com/FrancoStino/opencode-skills-collection/issues) to avoid duplicates
+        - Check if the skill already exists in the [upstream repo](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills)
+
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Pre-filing checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+        - label: I have checked the upstream skills directory
+          required: true
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill Name
+      description: "The skill's identifier (e.g. `my-awesome-skill`)"
+      placeholder: "my-awesome-skill"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What does this skill do?
+      description: A clear, concise description of the skill's purpose and behavior.
+      placeholder: "This skill helps users do X by automating Y..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Which category best fits this skill?
+      options:
+        - agent-behavior
+        - ai-ml
+        - api-integration
+        - automation
+        - backend
+        - cloud
+        - code-quality
+        - content
+        - data
+        - database
+        - design
+        - devops
+        - development
+        - frontend
+        - security
+        - testing
+        - uncategorized
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk Level
+      description: |
+        Does this skill require elevated permissions or access to sensitive resources?
+        - **safe**: Read-only, no special permissions needed
+        - **critical**: Writes files, executes commands, or accesses external services
+        - **offensive**: Security testing, penetration testing, exploit-related
+      options:
+        - safe
+        - critical
+        - offensive
+        - unknown
+    validations:
+      required: true
+
+  - type: input
+    id: source-repo
+    attributes:
+      label: Source Repository
+      description: "If this skill exists in another repo, provide the URL"
+      placeholder: "https://github.com/org/repo"
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe a concrete scenario where this skill would be useful.
+      placeholder: |
+        When I need to do X, I currently have to:
+        1. Step one...
+        2. Step two...
+        This skill would automate that.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Anything else — links to docs, similar skills, screenshots, etc.
+    validations:
+      required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@opencode-ai/sdk": "^1.15.5",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^25.9.1",
         "@types/strip-json-comments": "^3.0.0",
         "typescript": "^6.0.2"


### PR DESCRIPTION
## Summary

Adds structured GitHub Issue Forms for skill addition requests and bug reports.

## Templates

| Template | Purpose |
|----------|---------|
| `skill-addition.yml` | Request new skills with structured fields (name, category, risk, source, use case) |
| `bug-report.yml` | Report bugs with reproduction steps, expected behavior, and logs |
| `config.yml` | Disables blank issues, adds contact links |

## Why

Contributors were opening PRs directly instead of requesting skills via issues. These templates enforce structured input and guide contributors to the right workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub Issue Forms for skill addition requests and bug reports. Also updates `@types/bun` to `latest`.

- **New Features**
  - `skill-addition.yml`: fields for skill name, description, category, risk level, source repo, use case, and a pre-filing checklist.
  - `bug-report.yml`: fields for description, repro steps, expected behavior, version, logs, and a pre-filing checklist.
  - `config.yml`: disables blank issues and adds links for bug reports and security disclosures.

<sup>Written for commit 388a75bbca89515b2f3d9b529ed0008c33c3a2a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/opencode-skills-collection/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three GitHub Issue Form templates to standardize contributor submissions — a `bug-report.yml`, a `skill-addition.yml`, and a `config.yml` that disables blank issues — along with an unrelated `package-lock.json` change that syncs `@types/bun` to match what `package.json` already specifies.

- **`bug-report.yml` / `skill-addition.yml`**: Well-structured forms with sensible required/optional field splits and a pre-filing duplicate-check checklist.
- **`config.yml`**: Disables blank issues and adds contact links, but the "Bug Report" contact link duplicates the `bug-report.yml` template that is already surfaced in the template chooser, causing a double-entry in the GitHub UI.
- **`package-lock.json`**: Contains an unrelated `@types/bun` version-specifier update (`"*"` → `"latest"`) that is an artifact of running `npm install` locally and should ideally be in a separate commit.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the templates are well-formed and the only actionable concern is a duplicate Bug Report entry in the template chooser caused by config.yml.

The three issue form templates are correct and well-structured. The one UX issue is that config.yml adds a Bug Report contact link that mirrors the bug-report.yml template already shown in the chooser, so contributors will see the same option twice. The package-lock.json change is an unrelated side effect that carries no risk but adds diff noise.

.github/ISSUE_TEMPLATE/config.yml — the Bug Report contact link should be removed or replaced with a genuinely external resource.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug-report.yml | New GitHub issue form for bug reports; well-structured with required fields (description, repro steps, expected behavior) and optional fields (version, logs). No issues found. |
| .github/ISSUE_TEMPLATE/config.yml | Disables blank issues and adds contact links; the Bug Report contact link duplicates the bug-report.yml template already surfaced in the template chooser, creating a confusing double-entry for contributors. |
| .github/ISSUE_TEMPLATE/skill-addition.yml | New GitHub issue form for skill addition requests; comprehensive fields including name, description, category dropdown, risk level, source repo, and use case. Well-formed with appropriate required/optional designations. |
| package-lock.json | Unrelated lock-file update changing @types/bun from * to latest to match what package.json already specifies; no functional impact but adds unrelated churn to the diff. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Contributor opens New Issue] --> B{Template Chooser}
    B --> C[Skill Addition Request\nskill-addition.yml]
    B --> D[Bug Report\nbug-report.yml]
    B --> E[Contact Links Section]
    E --> F[Bug Report link\npoints to bug-report.yml\n⚠️ Duplicate of D]
    E --> G[Security Disclosure\nSECURITY.md]
    C --> H[Structured form:\nname, category, risk,\nsource, use case]
    D --> I[Structured form:\ndescription, repro steps,\nexpected behavior, logs]
```

<a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22francostino%2Fopencode-skills-collection%22%20on%20the%20existing%20branch%20%22feat%2Fissue-templates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fissue-templates%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2FISSUE_TEMPLATE%2Fconfig.yml%3A3-5%0A**Duplicate%20%22Bug%20Report%22%20entry%20in%20template%20chooser**%0A%0A%60config.yml%60%20adds%20a%20%22Bug%20Report%22%20contact%20link%20that%20points%20to%20the%20%60bug-report.yml%60%20template%20URL.%20Because%20%60bug-report.yml%60%20is%20already%20registered%20as%20a%20GitHub%20issue%20template%2C%20it%20will%20appear%20in%20the%20template%20chooser%20as%20a%20proper%20card%20AND%20again%20as%20a%20contact%20link%20at%20the%20bottom%20of%20the%20same%20chooser.%20%60contact_links%60%20are%20intended%20for%20external%20resources%20%28e.g.%2C%20Discord%2C%20Slack%2C%20docs%20sites%29%2C%20not%20for%20issue%20templates%20that%20are%20already%20surfaced%20in%20the%20same%20chooser.%20Contributors%20will%20see%20the%20same%20option%20twice%2C%20which%20is%20confusing.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackage-lock.json%3A17%0A**Unrelated%20lock-file%20change%20included%20in%20template%20PR**%0A%0AThe%20%60%40types%2Fbun%60%20entry%20is%20updated%20from%20%60%22*%22%60%20to%20%60%22latest%22%60%20here%2C%20which%20appears%20to%20be%20an%20artifact%20of%20running%20%60npm%20install%60%20locally%20%28the%20%60package.json%60%20already%20specifies%20%60%22latest%22%60%29.%20This%20change%20is%20unrelated%20to%20the%20GitHub%20issue%20templates%20being%20added%20and%20adds%20noise%20to%20the%20diff.%20Consider%20squashing%20or%20reverting%20this%20before%20merging%20so%20template%20and%20dependency%20changes%20stay%20in%20separate%20commits.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=francostino%2Fopencode-skills-collection&uid=101442&ts=1780571031&sig=f6390631fef840c91ca262db2944c303b39e5f1f6a3fb683051ed0180576ec17&pr=63&platform=github&fid=bb03014a-f043-4aa2-885f-1509dbcb9be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=3"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: update @types/bun dependency to l..."](https://github.com/francostino/opencode-skills-collection/commit/388a75bbca89515b2f3d9b529ed0008c33c3a2a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35595609)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->