### PR TITLE
Develop

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill in the details below.
+
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Pre-filing checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is.
+      placeholder: "When I do X, I expect Y, but Z happens."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Load skill '...'
+        2. Run command '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Plugin Version
+      description: "Output of `opencode --version` or check package.json"
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Paste any relevant error messages or logs.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Anything else — OS, environment, screenshots, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -58,7 +58,7 @@ body:
     id: logs
     attributes:
       label: Relevant Log Output
-      description: Paste any relevant error messages or logs.
+      description: "Warning: remove or redact any secrets, tokens, credentials, IPs, or personal data before posting logs. Paste any relevant error messages or logs."
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Bug Report
-    url: https://github.com/FrancoStino/opencode-skills-collection/issues/new?template=bug-report.yml
-    about: Report a bug or unexpected behavior
   - name: Security Disclosure
     url: https://github.com/FrancoStino/opencode-skills-collection/blob/main/SECURITY.md
     about: For security issues, follow responsible disclosure policy. Do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Report
+    url: https://github.com/FrancoStino/opencode-skills-collection/issues/new?template=bug-report.yml
+    about: Report a bug or unexpected behavior
+  - name: Security Disclosure
+    url: https://github.com/FrancoStino/opencode-skills-collection/blob/main/SECURITY.md
+    about: For security issues, follow responsible disclosure policy. Do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/skill-addition.yml
+++ b/.github/ISSUE_TEMPLATE/skill-addition.yml
@@ -1,0 +1,115 @@
+name: Skill Addition Request
+description: Request a new skill to be added to the collection
+title: "[Skill] "
+labels: ["skill-request", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Request a New Skill
+
+        Before submitting, please:
+        - Search [existing issues](https://github.com/FrancoStino/opencode-skills-collection/issues) to avoid duplicates
+        - Check if the skill already exists in the [upstream repo](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills)
+
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Pre-filing checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+        - label: I have checked the upstream skills directory
+          required: true
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill Name
+      description: "The skill's identifier (e.g. `my-awesome-skill`)"
+      placeholder: "my-awesome-skill"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What does this skill do?
+      description: A clear, concise description of the skill's purpose and behavior.
+      placeholder: "This skill helps users do X by automating Y..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Which category best fits this skill?
+      options:
+        - agent-behavior
+        - ai-ml
+        - api-integration
+        - automation
+        - backend
+        - cloud
+        - code-quality
+        - content
+        - data
+        - database
+        - design
+        - devops
+        - development
+        - frontend
+        - security
+        - testing
+        - uncategorized
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk Level
+      description: |
+        Does this skill require elevated permissions or access to sensitive resources?
+        - **safe**: Read-only, no special permissions needed
+        - **critical**: Writes files, executes commands, or accesses external services
+        - **offensive**: Security testing, penetration testing, exploit-related
+      options:
+        - safe
+        - critical
+        - offensive
+        - unknown
+    validations:
+      required: true
+
+  - type: input
+    id: source-repo
+    attributes:
+      label: Source Repository
+      description: "If this skill exists in another repo, provide the URL"
+      placeholder: "https://github.com/org/repo"
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe a concrete scenario where this skill would be useful.
+      placeholder: |
+        When I need to do X, I currently have to:
+        1. Step one...
+        2. Step two...
+        This skill would automate that.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Anything else — links to docs, similar skills, screenshots, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/skill-addition.yml
+++ b/.github/ISSUE_TEMPLATE/skill-addition.yml
@@ -76,7 +76,7 @@ body:
         - **safe**: Read-only, no special permissions needed
         - **critical**: Writes files, executes commands, or accesses external services
         - **offensive**: Security testing, penetration testing, exploit-related
-      options:
+        - none
         - safe
         - critical
         - offensive

--- a/.github/ISSUE_TEMPLATE/skill-addition.yml
+++ b/.github/ISSUE_TEMPLATE/skill-addition.yml
@@ -76,6 +76,7 @@ body:
         - **safe**: Read-only, no special permissions needed
         - **critical**: Writes files, executes commands, or accesses external services
         - **offensive**: Security testing, penetration testing, exploit-related
+      options:
         - none
         - safe
         - critical
@@ -83,6 +84,7 @@ body:
         - unknown
     validations:
       required: true
+
 
   - type: input
     id: source-repo

--- a/.github/ISSUE_TEMPLATE/skill-addition.yml
+++ b/.github/ISSUE_TEMPLATE/skill-addition.yml
@@ -8,6 +8,11 @@ body:
       value: |
         ## Request a New Skill
 
+        > **Note:** Skills here are synced nightly from the upstream repo
+        > [`sickn33/antigravity-awesome-skills`](https://github.com/sickn33/antigravity-awesome-skills).
+        > The fastest way to add a skill is to **open a PR upstream** — once merged, it lands here
+        > automatically. Use this issue to request a skill or track one you'd like added.
+
         Before submitting, please:
         - Search [existing issues](https://github.com/FrancoStino/opencode-skills-collection/issues) to avoid duplicates
         - Check if the skill already exists in the [upstream repo](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills)
@@ -73,9 +78,11 @@ body:
       label: Risk Level
       description: |
         Does this skill require elevated permissions or access to sensitive resources?
-        - **safe**: Read-only, no special permissions needed
-        - **critical**: Writes files, executes commands, or accesses external services
-        - **offensive**: Security testing, penetration testing, exploit-related
+        - **none**: No risk assessment
+        - **safe**: Verified safe — read-only, no special permissions needed
+        - **critical**: Contains sensitive operations (writes files, executes commands, or accesses external services)
+        - **offensive**: Contains offensive security tools (exploits, reverse shells, etc.)
+        - **unknown**: Not yet classified
       options:
         - none
         - safe
@@ -84,7 +91,6 @@ body:
         - unknown
     validations:
       required: true
-
 
   - type: input
     id: source-repo

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@opencode-ai/sdk": "^1.15.5",
-        "@types/bun": "latest",
+        "@types/bun": "*",
         "@types/node": "^25.9.1",
         "@types/strip-json-comments": "^3.0.0",
         "typescript": "^6.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,19 +99,19 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.11.tgz",
-      "integrity": "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ==",
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.13.tgz",
+      "integrity": "sha512-NFwZGhmxIPijtfz9swPJXDmhOpq4UWP8WjEE7GEMr7FwtJrK/hv6v36nFimed5+OKk+pQCrTJn/vhRW7Io72IA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.15.11",
+        "@opencode-ai/sdk": "1.15.13",
         "effect": "4.0.0-beta.66",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.2.15",
-        "@opentui/keymap": ">=0.2.15",
-        "@opentui/solid": ">=0.2.15"
+        "@opentui/core": ">=0.2.16",
+        "@opentui/keymap": ">=0.2.16",
+        "@opentui/solid": ">=0.2.16"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.11.tgz",
-      "integrity": "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w==",
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.13.tgz",
+      "integrity": "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@opencode-ai/sdk": "^1.15.5",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^25.9.1",
         "@types/strip-json-comments": "^3.0.0",
         "typescript": "^6.0.2"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@opencode-ai/sdk": "^1.15.5",
-    "@types/bun": "latest",
+    "@types/bun": "*",
     "@types/node": "^25.9.1",
     "@types/strip-json-comments": "^3.0.0",
     "typescript": "^6.0.2"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured GitHub issue templates for bug reports and skill requests, clarify the upstream PR workflow, document all `risk` levels in the skill form, and bump `@opencode-ai/plugin`/`@opencode-ai/sdk` to `1.15.13`.

- **New Features**
  - Added `.github/ISSUE_TEMPLATE/bug-report.yml` and `skill-addition.yml` with required fields.
  - Clarified the upstream submission path to `sickn33/antigravity-awesome-skills`.
  - Documented all `risk` levels (`none`, `safe`, `critical`, `offensive`, `unknown`) and fixed dropdown options.
  - Disabled blank issues and kept only a Security Disclosure contact link.

- **Dependencies**
  - Bumped `@opencode-ai/plugin`/`@opencode-ai/sdk` to `1.15.13` and raised optional `@opentui/*` peer floor to `>=0.2.16`.
  - Set `@types/bun` to `*` (wildcard range).

<sup>Written for commit 4844cc77c101a9f1a9ef8774f8f6d50a156f0c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/opencode-skills-collection/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/francostino/opencode-skills-collection/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structured GitHub issue templates for bug reports and skill requests, disables blank issues, and bumps `@opencode-ai/plugin`/`@opencode-ai/sdk` to `1.15.13`.

- **Issue templates**: `bug-report.yml` and `skill-addition.yml` are well-formed with required fields, pre-filing checklists, and a corrected `risk` dropdown; `config.yml` keeps only the Security Disclosure contact link.
- **Dependency bump**: `@opencode-ai/plugin` and `@opencode-ai/sdk` move from `1.15.11` → `1.15.13`, with the optional `@opentui/*` peer floor raised to `>=0.2.16`.
- **`@types/bun`**: Changed from the npm dist-tag `latest` to the semver wildcard `*` in `package.json`, which is the more semantically correct way to express "any version".

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to GitHub metadata files and a routine patch-level dependency bump with no functional code modifications.

All changes are additive issue templates and a straightforward dependency upgrade. The templates are well-structured YAML, blank issues are properly disabled, and the lock file integrity hashes match the new versions. No functional code paths are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug-report.yml | New bug report template with required fields, pre-filing checklist, and a log section reminding users to redact secrets before posting. |
| .github/ISSUE_TEMPLATE/config.yml | Disables blank issues and retains only the Security Disclosure contact link; the previously flagged redundant Bug Report link is absent. |
| .github/ISSUE_TEMPLATE/skill-addition.yml | New skill-request template with fixed risk dropdown (none/safe/critical/offensive/unknown), upstream repo reference, and required use-case field. |
| package.json | Changes `@types/bun` from the dist-tag `latest` to the semver wildcard `*`; `@opencode-ai/sdk` devDependency range (`^1.15.5`) unchanged but lock file resolves it to 1.15.13 within range. |
| package-lock.json | Bumps `@opencode-ai/plugin` and `@opencode-ai/sdk` from 1.15.11 to 1.15.13, raises `@opentui/*` optional peer floor to `>=0.2.16`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens new Issue] --> B{blank_issues_enabled: false}
    B --> C[GitHub Template Chooser]
    C --> D[Bug Report\nbug-report.yml]
    C --> E[Skill Addition Request\nskill-addition.yml]
    C --> F[Security Disclosure\ncontact link → SECURITY.md]
    D --> G[Pre-filing checklist\nDescription, Steps, Expected,\nVersion, Logs]
    E --> H[Pre-filing checklist\nSkill Name, Description,\nCategory, Risk, Use Case]
    G --> I[Labels: bug, triage]
    H --> J[Labels: skill-request, triage]
```

<sub>Reviews (7): Last reviewed commit: ["fix(issue-template): clarify upstream-PR..."](https://github.com/francostino/opencode-skills-collection/commit/4844cc77c101a9f1a9ef8774f8f6d50a156f0c22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35596868)</sub>

<!-- /greptile_comment -->