### PR TITLE
Develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,10 +125,20 @@
         }
       }
     },
-    "node_modules/@opencode-ai/sdk": {
+    "node_modules/@opencode-ai/plugin/node_modules/@opencode-ai/sdk": {
       "version": "1.15.13",
       "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.13.tgz",
       "integrity": "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.0.tgz",
+      "integrity": "sha512-a4Fw6lEZqXhjkyTH0LNInntrdLaWcz9M1+eqQgSVqI6PAlcqC/Jo069k8VdGcU3u4qbETqmURec8+VfhS06Sqg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,19 +99,19 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.13.tgz",
-      "integrity": "sha512-NFwZGhmxIPijtfz9swPJXDmhOpq4UWP8WjEE7GEMr7FwtJrK/hv6v36nFimed5+OKk+pQCrTJn/vhRW7Io72IA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.0.tgz",
+      "integrity": "sha512-YiS6lTCMJ00CiJ9x31RnntkEPYgkDU+uL5bGkUgsJoUGUrxrwYNLvEKl5/UaslWuMP/nlRSZyV/6ZR+G71LCjA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.15.13",
-        "effect": "4.0.0-beta.66",
+        "@opencode-ai/sdk": "1.17.0",
+        "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.2.16",
-        "@opentui/keymap": ">=0.2.16",
-        "@opentui/solid": ">=0.2.16"
+        "@opentui/core": ">=0.3.4",
+        "@opentui/keymap": ">=0.3.4",
+        "@opentui/solid": ">=0.3.4"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -125,20 +125,10 @@
         }
       }
     },
-    "node_modules/@opencode-ai/plugin/node_modules/@opencode-ai/sdk": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.13.tgz",
-      "integrity": "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "7.0.6"
-      }
-    },
     "node_modules/@opencode-ai/sdk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.0.tgz",
       "integrity": "sha512-a4Fw6lEZqXhjkyTH0LNInntrdLaWcz9M1+eqQgSVqI6PAlcqC/Jo069k8VdGcU3u4qbETqmURec8+VfhS06Sqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -216,21 +206,21 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
-      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
+      "version": "4.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
+      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
+        "fast-check": "^4.8.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
+        "ini": "^7.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
+        "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/fast-check": {
@@ -262,12 +252,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/isexe": {
@@ -283,12 +273,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
-      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -423,9 +413,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/francostino/opencode-skills-collection/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates dependencies to align with `@opencode-ai` 1.17.0 and refreshes the lockfile. Also bumps `@types/node` to the latest patch. No app code changes.

- **Dependencies**
  - `@opencode-ai/plugin` 1.15.13 → 1.17.0 (peer deps now `@opentui/* >=0.3.4`)
  - `@opencode-ai/sdk` 1.15.13 → 1.17.0
  - `@types/node` 25.9.1 → 25.9.2 (dev)
  - Transitive: `effect` 4.0.0-beta.74, `ini` 7.0.0, `msgpackr` 2.0.4, `uuid` 14.0.0

- **Migration**
  - Ensure Node is 22.22+, 24.15+, or 26+ (required by `ini@7` via `effect`).
  - If using `@opentui/*`, upgrade to >=0.3.4 to satisfy plugin peer deps.

<sup>Written for commit 4d24ef044d9f0c0dba91e7ed04b456b2b5170e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/opencode-skills-collection/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

