### PR TITLE
Develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@opencode-ai/sdk": "^1.15.5",
         "@types/bun": "*",
-        "@types/node": "^25.9.1",
+        "@types/node": "^26.0.0",
         "@types/strip-json-comments": "^3.0.0",
         "typescript": "^6.0.2"
       }
@@ -151,13 +151,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/strip-json-comments": {
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,12 +99,12 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.17.8",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.8.tgz",
-      "integrity": "sha512-pkmnYQz5d+xf0h6fAjgplSSJKLqgYKOXr+x6y40GRPdW+/IfndFkMGq7CDsG2SieGD84qv4zYDMyolGo06IMpw==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.9.tgz",
+      "integrity": "sha512-RvYsX2k90ew0P3c0R/Jrt6UOdA5CYf4GmYuREDKHx31GSJ25WKg9hrTzkcwCfvPPCpaBc53Qq6Fon9aWr+58ag==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.17.8",
+        "@opencode-ai/sdk": "1.17.9",
         "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.8",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.8.tgz",
-      "integrity": "sha512-6MKmsj2ujZyL44jy+12dpwWYDYKPS9fUr+0wVQxaIlPYQ/eAt8T8T3QrybplJ5ZtHfZUX+esXZ02x2UYYm7oEw==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.9.tgz",
+      "integrity": "sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@opencode-ai/sdk": "^1.15.5",
     "@types/bun": "*",
-    "@types/node": "^25.9.1",
+    "@types/node": "^26.0.0",
     "@types/strip-json-comments": "^3.0.0",
     "typescript": "^6.0.2"
   }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Node type definitions to v26 and bump `@opencode-ai/plugin` to 1.17.9. Keeps dev types current and pulls in the latest plugin fixes with no app code changes.

- **Dependencies**
  - `@types/node` to `^26.0.0` (major)
  - `@opencode-ai/plugin` to `1.17.9` (patch)
  - Transitive: `@opencode-ai/sdk` to `1.17.9`, `undici-types` to `8.3.0`

<sup>Written for commit 64046cd31f9b2b812f8cbeeb62cdab28880f23b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/opencode-skills-collection/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates three dependency groups: `@types/node` is bumped from `^25.9.1` to `^26.0.0` (a major version), `@opencode-ai/plugin` and its bundled `@opencode-ai/sdk` are patched from `1.17.8` to `1.17.9`, and the transitive `undici-types` package is updated from `7.24.6` to `8.3.0` as a consequence of the Node types major bump.

- The `@types/node` v25 → v26 jump is a major version change; the resolved `undici-types` range shifts from `>=7.24.0 <7.24.7` to `~8.3.0`, both of which are breaking-range transitions for those type definitions.
- `@opencode-ai/plugin` and `@opencode-ai/sdk` are patch bumps (`1.17.8` → `1.17.9`) with no manifest-level constraint change, and the lock file deduplicates the SDK correctly against the existing `^1.15.5` dev dependency range.

<h3>Confidence Score: 4/5</h3>

Safe to merge for runtime behavior; the only risk is a potential TypeScript compilation failure from the @types/node major bump and its transitive undici-types major change.

All changes are dev dependencies with no runtime impact. The @types/node v25 → v26 and undici-types v7 → v8 jumps are major-version transitions that could silently break the TypeScript build if any code touches fetch/HTTP types, but there is no evidence of a broken build in this diff.

package-lock.json — the undici-types major version jump is the only item worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Bumps @types/node dev dependency from ^25.9.1 to ^26.0.0 (major version); all other fields unchanged. |
| package-lock.json | Lock file reflects @types/node 26.0.0, @opencode-ai/plugin/sdk 1.17.9 patch bumps, and the major undici-types jump from 7.24.6 to 8.3.0 as a transitive consequence. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\n@types/node ^26.0.0\n@opencode-ai/plugin ^1.15.5"] -->|resolves to| B["@types/node 26.0.0\n(was 25.9.3)"]
    A -->|resolves to| C["@opencode-ai/plugin 1.17.9\n(was 1.17.8)"]
    B -->|requires| D["undici-types ~8.3.0\n→ 8.3.0 (was 7.24.6)"]
    C -->|requires| E["@opencode-ai/sdk 1.17.9\n(was 1.17.8)"]
    F["devDependency: @opencode-ai/sdk ^1.15.5"] -->|deduped to| E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["package.json\n@types/node ^26.0.0\n@opencode-ai/plugin ^1.15.5"] -->|resolves to| B["@types/node 26.0.0\n(was 25.9.3)"]
    A -->|resolves to| C["@opencode-ai/plugin 1.17.9\n(was 1.17.8)"]
    B -->|requires| D["undici-types ~8.3.0\n→ 8.3.0 (was 7.24.6)"]
    C -->|requires| E["@opencode-ai/sdk 1.17.9\n(was 1.17.8)"]
    F["devDependency: @opencode-ai/sdk ^1.15.5"] -->|deduped to| E
```

</a>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22francostino%2Fopencode-skills-collection%22%20on%20the%20existing%20branch%20%22develop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22develop%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackage-lock.json%3A163%0A**%60undici-types%60%20major%20version%20bump%20via%20%60%40types%2Fnode%60%20upgrade**%0A%0A%60%40types%2Fnode%60%20v26%20changes%20its%20peer%20range%20for%20%60undici-types%60%20from%20%60%3E%3D7.24.0%20%3C7.24.7%60%20%28very%20tight%29%20to%20%60~8.3.0%60%2C%20pulling%20in%20a%20major%20version%20jump%20%287%20%E2%86%92%208%29%20as%20a%20transitive%20dev%20dependency.%20%60undici-types%60%20publishes%20breaking%20HTTP%2Ffetch%20type%20changes%20between%20majors%2C%20so%20any%20code%20that%20imports%20from%20%60undici%60%20directly%20or%20uses%20%60fetch%60-related%20global%20types%20may%20see%20type%20errors%20after%20this%20bump.%20Worth%20confirming%20the%20TypeScript%20build%20still%20passes%20cleanly%20after%20this%20update.%0A%0A&repo=francostino%2Fopencode-skills-collection&tid=70573&ts=1782288772&sig=61737af3b4b0378bbcbb633084629e3c9dfa7c60e4d678eb07cab52c4f99c7f8&pr=77&platform=github&fid=1069ab22-6552-4549-b4a7-37ef225b2036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #74 from FrancoStino/..."](https://github.com/francostino/opencode-skills-collection/commit/64046cd31f9b2b812f8cbeeb62cdab28880f23b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39501070)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->