### PR TITLE
Develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     target-branch: "develop"
     exclude-paths:
       - "bundled-skills/**"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/.github/workflows/merge-branch.yml
+++ b/.github/workflows/merge-branch.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Merge main to develop

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish to npm
 
 on:
   workflow_run:
-    workflows: ["Create Release", "Auto-Sync Skills"]
-    types: [completed]
+    workflows: [ "Create Release", "Auto-Sync Skills" ]
+    types: [ completed ]
   workflow_dispatch:
 
 jobs:
@@ -22,9 +22,8 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,8 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '24'
           cache: 'npm'
       - name: Configure git
         run: |

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Sync skills
         run: |
           rm -rf bundled-skills
-          npx --yes antigravity-awesome-skills --path "bundled-skills"
+          npx --yes antigravity-awesome-skills --path "$GITHUB_WORKSPACE/bundled-skills"
       - name: Download skills_index.json from upstream
         run: |
           curl -fsSL \

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -10,14 +10,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.0.0
         with:
-          node-version: '24'
           cache: 'npm'
       - name: Configure git
         run: |


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Modernizes CI by upgrading key GitHub Actions, removing the deprecated Node 24 pin, and fixing the skills sync path. Adds Dependabot support to keep `github-actions` up to date on `develop`.

- **Dependencies**
  - Add Dependabot updates for `github-actions` (weekly, target `develop`).
  - Update `actions/setup-node` to `v6` (publish, release, sync-skills) and remove the hard-coded Node `24` across workflows.
  - Update `actions/checkout` to `v7` in sync-skills.

- **Bug Fixes**
  - Sync skills now writes to `$GITHUB_WORKSPACE/bundled-skills` to ensure the correct path in CI.

<sup>Written for commit 83d6e8ef7ccd95cf774738279b8b349f4ebaea41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/opencode-skills-collection/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the repository automation workflows. The main changes are:

- Adds Dependabot updates for GitHub Actions on `develop`.
- Updates several workflow action versions.
- Removes explicit Node 24 pins from release and automation jobs.
- Uses `GITHUB_WORKSPACE` when syncing bundled skills.

<h3>Confidence Score: 4/5</h3>

The release and publish paths should keep an explicit Node runtime before merging.

- The workflow changes are small and mostly consistent with the documented automation flow.
- The Node setup changes make release jobs depend on the runner default instead of the previously pinned Node 24.
- The Dependabot and workflow trigger changes did not show a separate concrete breakage.

.github/workflows/publish.yml and the sibling workflows that removed `node-version`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds weekly GitHub Actions updates targeting `develop`, matching the existing branch strategy. |
| .github/workflows/publish.yml | Updates setup-node and removes the explicit Node 24 runtime from the publish path. |
| .github/workflows/release.yml | Updates setup-node and removes the explicit Node 24 runtime from the main release path. |
| .github/workflows/beta-release.yml | Removes the explicit Node 24 runtime from the beta release workflow. |
| .github/workflows/merge-branch.yml | Removes the explicit Node 24 runtime from the merge automation workflow. |
| .github/workflows/sync-skills.yml | Updates checkout/setup-node versions, changes the sync path, and removes the explicit Node 24 runtime. |

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22francostino%2Fopencode-skills-collection%22%20on%20the%20existing%20branch%20%22develop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22develop%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpublish.yml%3A25-28%0A**Release%20Runtime%20Becomes%20Implicit**%0A%0AThis%20setup%20step%20no%20longer%20pins%20Node%2024%2C%20so%20the%20publish%20workflow%20now%20runs%20%60npm%20ci%60%2C%20typecheck%2C%20build%2C%20and%20%60npm%20publish%60%20on%20the%20runner%20image's%20default%20Node%20instead%20of%20the%20runtime%20the%20release%20path%20used%20before.%20When%20that%20default%20differs%20or%20changes%2C%20this%20workflow%20can%20fail%20during%20release%20or%20publish%20artifacts%20built%20under%20an%20unintended%20Node%20version.%0A%0A&repo=francostino%2Fopencode-skills-collection&tid=70573&ts=1783409647&sig=ae96c818d4421d4eaffb7589e7711ed1ab2b8d112fbdaac15e76446d90f7c88b&pr=83&platform=github&fid=eb51bf3b-975b-44b9-b16f-a162fe26a6c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=6"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: update Node.js setup to use version ..."](https://github.com/francostino/opencode-skills-collection/commit/83d6e8ef7ccd95cf774738279b8b349f4ebaea41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42295133)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=a0874d39-0a5e-4338-a068-b193d0ba4c8c))

<!-- /greptile_comment -->