### PR TITLE
chore: update references from antigravity-awesome-skills to agentic-awesome-skills

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill-addition.yml
+++ b/.github/ISSUE_TEMPLATE/skill-addition.yml
@@ -9,13 +9,13 @@ body:
         ## Request a New Skill
 
         > **Note:** Skills here are synced nightly from the upstream repo
-        > [`sickn33/antigravity-awesome-skills`](https://github.com/sickn33/antigravity-awesome-skills).
+        > [`sickn33/agentic-awesome-skills`](https://github.com/sickn33/agentic-awesome-skills).
         > The fastest way to add a skill is to **open a PR upstream** — once merged, it lands here
         > automatically. Use this issue to request a skill or track one you'd like added.
 
         Before submitting, please:
         - Search [existing issues](https://github.com/FrancoStino/opencode-skills-collection/issues) to avoid duplicates
-        - Check if the skill already exists in the [upstream repo](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills)
+        - Check if the skill already exists in the [upstream repo](https://github.com/sickn33/agentic-awesome-skills/tree/main/skills)
 
   - type: checkboxes
     id: searched

--- a/.github/ISSUE_TEMPLATE/skill-source-request.yml
+++ b/.github/ISSUE_TEMPLATE/skill-source-request.yml
@@ -17,7 +17,7 @@ body:
       options:
         - label: I have searched existing issues and this is not a duplicate
           required: true
-        - label: I have checked the [upstream skills directory](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills)
+        - label: I have checked the [upstream skills directory](https://github.com/sickn33/agentic-awesome-skills/tree/main/skills)
           required: true
 
   - type: dropdown

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Sync skills
         run: |
           rm -rf bundled-skills
-          npx --yes antigravity-awesome-skills --path "$GITHUB_WORKSPACE/bundled-skills"
+          npx --yes agentic-awesome-skills --path "$GITHUB_WORKSPACE/bundled-skills"
       - name: Download skills_index.json from upstream
         run: |
           curl -fsSL \
-            "https://raw.githubusercontent.com/sickn33/antigravity-awesome-skills/main/skills_index.json" \
+            "https://raw.githubusercontent.com/sickn33/agentic-awesome-skills/main/skills_index.json" \
             -o skills_index.json
           node -e "JSON.parse(require('fs').readFileSync('skills_index.json','utf8'))"
           echo "✅ skills_index.json valid ($(wc -c < skills_index.json) bytes)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,13 @@ OpenCode plugin (npm: `opencode-skills-collection`) that bundles 1400+ AI skills
 
 ## ⚠️ Generated files — never edit directly
 
-`bundled-skills/` and `skills_index.json` are **destroyed and regenerated nightly** by `.github/workflows/sync-skills.yml` from upstream repo `sickn33/antigravity-awesome-skills`.
+`bundled-skills/` and `skills_index.json` are **destroyed and regenerated nightly** by `.github/workflows/sync-skills.yml` from upstream repo `sickn33/agentic-awesome-skills`.
 
 - The workflow runs `rm -rf bundled-skills` then re-downloads everything
 - `skills_index.json` is overwritten from upstream's `main` branch
 - Any local changes to these paths **will be lost**
 
-**To add or modify skills:** submit a PR to [`sickn33/antigravity-awesome-skills`](https://github.com/sickn33/antigravity-awesome-skills). After merge, the nightly sync brings changes here automatically.
+**To add or modify skills:** submit a PR to [`sickn33/agentic-awesome-skills`](https://github.com/sickn33/agentic-awesome-skills). After merge, the nightly sync brings changes here automatically.
 
 **To add skills from external sources:** clone the source repo, copy files programmatically with a script. Never write SKILL.md content by hand.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# Architecture
+
+## Pattern Overview
+
+**Overall:** Plugin-based SkillPointer pipeline — an OpenCode plugin that installs categorized AI skills from a bundled snapshot into a vault, then generates lightweight pointer files for runtime discovery.
+
+**Key Characteristics:**
+- Plugin lifecycle: runs once at OpenCode startup via `Plugin` hook interface
+- Vault-based storage: full skill content lives in a hidden vault (`~/.config/opencode/skill-libraries/`) to avoid token bloat at startup
+- Pointer indirection: OpenCode reads lightweight `SKILL.md` pointers in `~/.config/opencode/skills/`, each listing available skills and vault path — the agent loads full skill content on-demand via `view_file`
+- Content safety: CI-time scanning with regex patterns quarantines dangerous skills before npm publish; runtime patching applies config-driven find/replace fixes
+- Risk-based filtering: user-configurable `skill-filter.jsonc` excludes skills by risk level or ID
+
+## Layers
+
+**Plugin Entry:**
+- Purpose: Bootstrap the SkillPointer pipeline, resolve paths, handle top-level errors
+- Location: `src/index.ts`
+- Contains: Path resolution (`resolveBundledSkillsPath`, `resolveActiveSkillsDir`), the `OpenCodeSkillsCollection` plugin function
+- Depends on: `src/skill-pointer/index.ts` (`runSkillPointer`), `src/utils/fs.utils.ts` (`ensureDir`)
+- Used by: OpenCode runtime (loads as a plugin via `@opencode-ai/plugin`)
+
+**SkillPointer Orchestrator:**
+- Purpose: Sequence the full pipeline — load index, filter, install vault, patch content, generate pointers
+- Location: `src/skill-pointer/index.ts`
+- Contains: `runSkillPointer()` function, `SkillPointerOptions` interface, vault path resolution
+- Depends on: `vault-installer.ts`, `skill-risk-filter.ts`, `config-loader.ts`, `skill-patcher.ts`, `pointer-generator.ts`
+- Used by: `src/index.ts`
+
+**Vault Installer:**
+- Purpose: Load the skill index (from `skills_index.json` or by scanning `SKILL.md` frontmatter) and sync skill folders into the vault organized by category
+- Location: `src/skill-pointer/vault-installer.ts`
+- Contains: `loadSkillsIndex()`, `installSkillsToVault()`, `SkillIndexEntry` interface, frontmatter parsing, category derivation, path-traversal guards
+- Depends on: `src/utils/fs.utils.ts`, `src/constants/constants.ts`
+- Used by: `src/skill-pointer/index.ts`
+
+**Risk Filter:**
+- Purpose: Filter skill index entries by risk level or explicit exclusion list before installation
+- Location: `src/skill-pointer/skill-risk-filter.ts`
+- Contains: `shouldLoad()`, `filterIndex()`
+- Depends on: `src/skill-pointer/risk-level.ts` (`RiskLevel` type), `config-loader.ts` (`SkillRiskFilterConfig`)
+- Used by: `src/skill-pointer/index.ts`
+
+**Config Loader:**
+- Purpose: Load user-facing `skill-filter.jsonc` configuration (risk exclusions, scan patterns, content patches)
+- Location: `src/skill-pointer/config-loader.ts`
+- Contains: `loadFilterConfig()`, `SkillRiskFilterConfig`, `ScanPattern`, `SkillPatch` interfaces, default config, JSONC parsing via `strip-json-comments`
+- Depends on: `src/skill-pointer/risk-level.ts`
+- Used by: `src/skill-pointer/index.ts`, `src/skill-pointer/skill-risk-filter.ts`
+
+**Content Scanner:**
+- Purpose: Detect dangerous patterns in skill content (recursive invocation, aggressive matching) — used at CI time, not at runtime
+- Location: `src/skill-pointer/content-scanner.ts`
+- Contains: `scanSkills()`, `scanSkillContent()`, `mergePatterns()`, `DEFAULT_SCAN_PATTERNS`, `ScanResult`, `ScanOutput` interfaces
+- Depends on: `src/constants/constants.ts`
+- Used by: `scripts/ci-scan-skills.mjs` (CI pipeline)
+
+**Skill Patcher:**
+- Purpose: Apply config-driven regex find/replace patches to installed skill SKILL.md files in the vault
+- Location: `src/skill-pointer/skill-patcher.ts`
+- Contains: `applySkillPatches()`, path-traversal validation via `realpathSync`, grouped patch application
+- Depends on: `src/constants/constants.ts`
+- Used by: `src/skill-pointer/index.ts`
+
+**Pointer Generator:**
+- Purpose: Write lightweight `SKILL.md` pointer files into `~/.config/opencode/skills/` — one pointer per category listing all skills and vault path
+- Location: `src/skill-pointer/pointer-generator.ts`
+- Contains: `generatePointers()`, `buildPointerContent()` (Markdown with frontmatter, skill list, load instructions)
+- Depends on: `src/constants/constants.ts`, `src/utils/fs.utils.ts`
+- Used by: `src/skill-pointer/index.ts`
+
+**Constants:**
+- Purpose: Centralize shared string constants used across the plugin
+- Location: `src/constants/constants.ts`
+- Contains: `POINTER_SUFFIX` (`"-category-pointer"`), `SKILL_FILENAME` (`"SKILL.md"`), `VAULT_DIR_NAME` (`"skill-libraries"`), `UNCATEGORIZED_CATEGORY` (`"uncategorized"`)
+- Depends on: none
+- Used by: all skill-pointer modules
+
+**Utilities:**
+- Purpose: Shared filesystem helpers
+- Location: `src/utils/fs.utils.ts`
+- Contains: `ensureDir()` (recursive mkdir), `listSubdirectories()`
+- Depends on: `node:fs`
+- Used by: `src/index.ts`, `src/skill-pointer/index.ts`, `src/skill-pointer/vault-installer.ts`, `src/skill-pointer/pointer-generator.ts`
+
+## Data Flow
+
+**Startup Pipeline (runtime):**
+
+1. OpenCode loads the plugin — `src/index.ts` resolves `bundledSkillsPath` (from `dist/` relative to `__dirname`) and `activeSkillsDir` (`~/.config/opencode/skills/`)
+2. `runSkillPointer()` is called — `src/skill-pointer/index.ts`
+3. `loadSkillsIndex()` reads `skills_index.json` (or scans `SKILL.md` frontmatter as fallback) — `src/skill-pointer/vault-installer.ts`
+4. `loadFilterConfig()` reads `~/.config/opencode/skill-filter.jsonc` (JSONC with comments support) — `src/skill-pointer/config-loader.ts`
+5. `filterIndex()` removes skills matching excluded risk levels or IDs — `src/skill-pointer/skill-risk-filter.ts`
+6. `installSkillsToVault()` syncs skill folders from `bundled-skills/` into `~/.config/opencode/skill-libraries/<category>/`, removing stale skills not in the filtered index — `src/skill-pointer/vault-installer.ts`
+7. `applySkillPatches()` applies regex find/replace patches from config to installed SKILL.md files — `src/skill-pointer/skill-patcher.ts`
+8. `generatePointers()` writes category pointer folders (`<category>-category-pointer/SKILL.md`) into `~/.config/opencode/skills/`, cleaning up stale pointer directories — `src/skill-pointer/pointer-generator.ts`
+
+**CI Content Scanning (build time):**
+
+1. `scripts/ci-scan-skills.mjs` loads the compiled index and scanner from `dist/`
+2. `scanSkills()` tests every SKILL.md against merged default + config scan patterns — `src/skill-pointer/content-scanner.ts`
+3. Quarantined skills (those matching `block`-severity patterns) are deleted from `bundled-skills/` and removed from `skills_index.json`
+4. Warnings are logged but skills are kept; exit code 0 on success
+
+## Key Abstractions
+
+**SkillIndexEntry:**
+- Purpose: Unified representation of a skill's metadata — id (folder name), category, name, description, risk level
+- Location: `src/skill-pointer/vault-installer.ts`
+- Pattern: Plain data interface
+
+**RiskLevel:**
+- Purpose: Classify skill safety — `"none" | "safe" | "critical" | "offensive" | "unknown"`
+- Location: `src/skill-pointer/risk-level.ts`
+- Pattern: Union type
+
+**SkillRiskFilterConfig:**
+- Purpose: User-facing configuration for filtering skills, scanning content, and patching skill files
+- Location: `src/skill-pointer/config-loader.ts`
+- Pattern: Configuration interface with safe defaults
+
+**SkillPointerOptions:**
+- Purpose: Input parameters for the orchestrator — bundled skills path, active skills dir, optional vault dir and config path overrides
+- Location: `src/skill-pointer/index.ts`
+- Pattern: Options interface
+
+**Pointer Files (`<category>-category-pointer/SKILL.md`):**
+- Purpose: Lightweight Markdown files with YAML frontmatter that list all skills in a category and provide vault path + load instructions for the agent
+- Location: Generated at runtime into `~/.config/opencode/skills/<category>-category-pointer/SKILL.md`
+- Pattern: Template-driven code generation
+
+## Entry Points
+
+**OpenCode Plugin Hook:**
+- Location: `src/index.ts` (default export `OpenCodeSkillsCollection`)
+- Triggers: OpenCode startup (plugin system loads the package)
+- Responsibilities: Resolve paths, ensure directories exist, invoke the full SkillPointer pipeline, catch and log errors to stderr
+
+**CI Scanner Script:**
+- Location: `scripts/ci-scan-skills.mjs`
+- Triggers: GitHub Actions workflow (`sync-skills.yml`) before npm publish
+- Responsibilities: Load index, scan all skills for dangerous patterns, remove quarantined skills from `bundled-skills/` and `skills_index.json`, emit GitHub Actions annotations
+
+## Error Handling
+
+**Strategy:** Fail-closed at the plugin level with stderr logging. The top-level `try/catch` in `src/index.ts` catches any pipeline failure and writes to `process.stderr`, then returns an empty plugin object — OpenCode continues without skills rather than crashing. Individual pipeline stages use safe defaults:
+- `loadFilterConfig()` returns empty defaults on missing file, parse errors, or invalid entries
+- `loadSkillsIndex()` falls back to scanning `SKILL.md` frontmatter when `skills_index.json` is missing or corrupt
+- `applySkillPatches()` silently skips invalid regex patterns and unmapped skill IDs
+- `content-scanner.ts` silently skips invalid regex patterns and preserves defaults when config overrides are invalid
+- Path-traversal guards (`isSafePath`, `isSafePathComponent`, `realpathSync` checks) prevent directory escapes in vault operations
+
+## Cross-Cutting Concerns
+
+**Storage:** Filesystem-based. Skills live as folders of files in `~/.config/opencode/skill-libraries/` (vault). Pointer files live in `~/.config/opencode/skills/`. Configuration lives in `~/.config/opencode/skill-filter.jsonc`. No database.
+
+**Logging:** `process.stderr.write()` for plugin-level errors. `console.warn()` in `content-scanner.ts` for invalid regex patterns. GitHub Actions `::warning::` annotations from CI script. No structured logging framework.
+
+**Caching:** None. The pipeline runs synchronously on every OpenCode startup. The vault is a file-level cache of bundled skills — `cpSync` with `force: true` ensures consistency on every run.
+
+**Security:** OWASP-aligned path traversal prevention. Every function that accepts user-derived or index-derived skill IDs validates components against `..`, `/`, and path separator injection. `realpathSync` ensures resolved paths stay within expected boundaries. Content scanning at CI time quarantines dangerous skill instructions before they reach the npm package. No secrets or credentials in code — configuration is user-authored JSONC.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,135 @@
+# Codebase Structure
+
+## Directory Layout
+
+```
+opencode-skills-collection/
+├── src/                              # TypeScript source — plugin + skill-pointer pipeline
+│   ├── index.ts                      # Plugin entry point (default export)
+│   ├── constants/
+│   │   └── constants.ts              # Shared string constants (POINTER_SUFFIX, SKILL_FILENAME, etc.)
+│   ├── skill-pointer/
+│   │   ├── index.ts                  # Pipeline orchestrator (runSkillPointer)
+│   │   ├── vault-installer.ts        # Load skill index, sync folders into vault
+│   │   ├── pointer-generator.ts      # Write category pointer SKILL.md files
+│   │   ├── skill-risk-filter.ts      # Risk-based skill filtering
+│   │   ├── config-loader.ts          # Load skill-filter.jsonc (JSONC config)
+│   │   ├── content-scanner.ts        # Dangerous pattern detection (CI-time)
+│   │   ├── skill-patcher.ts          # Regex find/replace patches on installed skills
+│   │   └── risk-level.ts             # RiskLevel union type
+│   ├── utils/
+│   │   └── fs.utils.ts              # ensureDir, listSubdirectories helpers
+│   └── __tests__/                    # Bun test suite (excluded from tsconfig compilation)
+│       ├── constants.test.ts
+│       ├── content-scanner.test.ts
+│       ├── pointer-generator.test.ts
+│       ├── skill-patcher.test.ts
+│       ├── skill-risk-filter.test.ts
+│       ├── vault-installer.test.ts
+│       └── test-helpers.ts           # Shared test utilities
+├── bundled-skills/                   # Pre-built skill folders (synced nightly from upstream)
+├── skills_index.json                 # Pre-built skill index JSON (synced nightly from upstream)
+├── scripts/
+│   └── ci-scan-skills.mjs           # CI script: scans and quarantines dangerous skills before publish
+├── dist/                             # Compiled output (tsc, .gitignored)
+├── docs/
+│   └── assets/                       # Documentation assets
+├── .github/
+│   └── workflows/
+│       ├── sync-skills.yml           # Nightly sync from upstream + release
+│       ├── publish.yml               # npm publish after sync/release
+│       ├── beta-release.yml          # Manual beta publish from develop
+│       ├── release.yml               # Manual version bump + GitHub release
+│       └── merge-branch.yml          # Merge develop → main
+├── package.json                      # npm package config (@opencode-ai/plugin, strip-json-comments)
+├── tsconfig.json                     # TypeScript config (ES2022, ESNext modules, bundler resolution)
+├── AGENTS.md                         # AI agent instructions for this repo
+├── README.md                         # Project documentation
+├── SECURITY.md                       # Security policy
+├── CHANGELOG.md                      # Release changelog
+├── BETA_CHANGELOG.md                 # Beta changelog
+├── CODEOWNERS                        # GitHub code ownership
+└── LICENSE                           # MIT license
+```
+
+## Directory Purposes
+
+**`src/`:**
+- Purpose: All TypeScript source code for the plugin
+- Contains: Plugin entry, skill-pointer pipeline modules, constants, utilities
+- Key files: `index.ts` (plugin entry), `skill-pointer/index.ts` (orchestrator)
+
+**`src/skill-pointer/`:**
+- Purpose: Core pipeline — the SkillPointer architecture that loads, filters, installs, patches, and generates pointers for skills
+- Contains: 8 TypeScript modules covering every pipeline stage
+- Key files: `vault-installer.ts` (index loading + vault sync), `pointer-generator.ts` (pointer file creation), `config-loader.ts` (user config parsing), `content-scanner.ts` (CI safety scanning), `skill-patcher.ts` (runtime content patches)
+
+**`src/constants/`:**
+- Purpose: Shared string constants referenced across modules
+- Contains: Single file with 4 exported constants
+- Key files: `constants.ts`
+
+**`src/utils/`:**
+- Purpose: Generic filesystem helpers
+- Contains: `ensureDir()` for recursive directory creation, `listSubdirectories()` for directory enumeration
+- Key files: `fs.utils.ts`
+
+**`src/__tests__/`:**
+- Purpose: Bun-based test suite covering pipeline modules
+- Contains: 6 test files + 1 test helper, excluded from TypeScript compilation
+- Key files: `test-helpers.ts`, one `*.test.ts` per major module
+
+**`bundled-skills/`:**
+- Purpose: Pre-packaged skill folders synced nightly from `sickn33/antigravity-awesome-skills`
+- Contains: Subdirectories per skill, each with a `SKILL.md` and optional assets
+- Key files: `skills_index.json` (at project root, not inside this dir)
+
+**`scripts/`:**
+- Purpose: CI automation scripts
+- Contains: Content scanner invoked before npm publish
+- Key files: `ci-scan-skills.mjs`
+
+**`.github/workflows/`:**
+- Purpose: GitHub Actions CI/CD pipelines
+- Contains: 5 workflow files for sync, publish, release, beta, and branch merge
+- Key files: `sync-skills.yml` (nightly + manual), `publish.yml`
+
+## Key File Locations
+
+**Entry Points:** `src/index.ts`: Plugin default export — invoked by OpenCode runtime at startup
+**Entry Points:** `scripts/ci-scan-skills.mjs`: CI entry — runs content scanning and quarantine before publish
+**Configuration:** `package.json`: npm package metadata, dependencies, build/test scripts
+**Configuration:** `tsconfig.json`: TypeScript compiler options (ES2022 target, ESNext modules, bundler resolution)
+**Configuration:** `~/.config/opencode/skill-filter.jsonc`: User-facing runtime config for risk filtering and content patches (not in repo)
+**Core Logic:** `src/skill-pointer/index.ts`: Pipeline orchestrator — sequences all stages
+**Core Logic:** `src/skill-pointer/vault-installer.ts`: Index loading and vault synchronization
+**Core Logic:** `src/skill-pointer/pointer-generator.ts`: Pointer file generation with Markdown templates
+**Core Logic:** `src/skill-pointer/config-loader.ts`: JSONC config parsing with validation
+**Core Logic:** `src/skill-pointer/content-scanner.ts`: Regex-based dangerous pattern detection
+**Core Logic:** `src/skill-pointer/skill-patcher.ts`: Regex find/replace content patching
+**Tests:** `src/__tests__/`: Bun test suite (run via `bun test`)
+**Generated:** `bundled-skills/`: Synced nightly — never edit directly
+**Generated:** `skills_index.json`: Synced nightly — never edit directly
+**Generated:** `dist/`: TypeScript compilation output — `.gitignored`
+
+## Naming Conventions
+
+**Files:** kebab-case for all source files (e.g., `vault-installer.ts`, `skill-risk-filter.ts`, `pointer-generator.ts`, `content-scanner.ts`)
+**Directories:** kebab-case (e.g., `skill-pointer/`, `constants/`, `utils/`)
+**Types:** PascalCase interfaces and type aliases (e.g., `SkillIndexEntry`, `RiskLevel`, `SkillPointerOptions`, `ScanPattern`)
+**Functions:** camelCase (e.g., `runSkillPointer`, `loadSkillsIndex`, `installSkillsToVault`, `generatePointers`, `applySkillPatches`)
+**Constants:** UPPER_SNAKE_CASE (e.g., `POINTER_SUFFIX`, `SKILL_FILENAME`, `VAULT_DIR_NAME`, `UNCATEGORIZED_CATEGORY`)
+**Test files:** `*.test.ts` co-located in `src/__tests__/`
+**Skill folders:** kebab-case (e.g., `laravel-expert`, `wordpress-core`, `php-pro`)
+
+## Where to Add New Code
+
+**New pipeline stage:** `src/skill-pointer/[stage-name].ts` — export a function, call it from `src/skill-pointer/index.ts` in the pipeline sequence
+**New constant:** `src/constants/constants.ts` — add an exported `const` with UPPER_SNAKE_CASE name
+**New utility:** `src/utils/[utility-name].ts` — keep functions generic and filesystem-related
+**New config field:** Add interface property to `SkillRiskFilterConfig` in `src/skill-pointer/config-loader.ts`, add parsing + validation in `loadFilterConfig()`
+**New scan pattern:** Add to `DEFAULT_SCAN_PATTERNS` array in `src/skill-pointer/content-scanner.ts`
+**New risk level:** Extend the `RiskLevel` union type in `src/skill-pointer/risk-level.ts`, add to `VALID_RISK_LEVELS` in `config-loader.ts`
+**New CI workflow:** `.github/workflows/[workflow-name].yml`
+**New test:** `src/__tests__/[module-name].test.ts` — use Bun test runner, import from compiled `dist/` or source directly
+**New pointer format:** Modify `buildPointerContent()` in `src/skill-pointer/pointer-generator.ts`

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -2,7 +2,7 @@
 
 ## Directory Layout
 
-```
+```text
 opencode-skills-collection/
 ├── src/                              # TypeScript source — plugin + skill-pointer pipeline
 │   ├── index.ts                      # Plugin entry point (default export)
@@ -80,7 +80,7 @@ opencode-skills-collection/
 - Key files: `test-helpers.ts`, one `*.test.ts` per major module
 
 **`bundled-skills/`:**
-- Purpose: Pre-packaged skill folders synced nightly from `sickn33/antigravity-awesome-skills`
+- Purpose: Pre-packaged skill folders synced nightly from `sickn33/agentic-awesome-skills`
 - Contains: Subdirectories per skill, each with a `SKILL.md` and optional assets
 - Key files: `skills_index.json` (at project root, not inside this dir)
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the upstream source and tooling from `sickn33/antigravity-awesome-skills` to `sickn33/agentic-awesome-skills`, and updates docs to match. Nightly sync now pulls from the new repo and CLI; contributor templates and docs link to the new upstream.

- **Dependencies**
  - Updated `.github/workflows/sync-skills.yml` to run `npx --yes agentic-awesome-skills` and download `skills_index.json` from `sickn33/agentic-awesome-skills`.
  - Updated issue templates and `AGENTS.md` to reference the new upstream repo.

- **New Features**
  - Added `ARCHITECTURE.md` describing the SkillPointer pipeline, data flow, and safety checks.
  - Added `STRUCTURE.md` documenting the codebase layout and key modules, now correctly stating `bundled-skills/` syncs from `sickn33/agentic-awesome-skills`.

<sup>Written for commit e347c4d02efd56dc0c187f693cb20a3c749f58b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/opencode-skills-collection/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the project references to the new upstream skills source. The main changes are:

- Workflow sync now uses `agentic-awesome-skills`.
- Issue templates now link contributors to the new upstream repo.
- Agent guidance now names the new generated-file source.
- Architecture and structure docs describe the SkillPointer pipeline.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/sync-skills.yml | Updates the nightly sync command and index download URL to the new upstream. |
| AGENTS.md | Updates generated-file guidance and contribution links to the new upstream. |
| STRUCTURE.md | Adds a structure guide that describes the repo layout and generated skill paths. |
| ARCHITECTURE.md | Adds architecture documentation for the SkillPointer runtime and CI pipeline. |

<sub>Reviews (3): Last reviewed commit: ["docs: update STRUCTURE.md to reflect new..."](https://github.com/francostino/opencode-skills-collection/commit/e347c4d02efd56dc0c187f693cb20a3c749f58b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43768673)</sub>

<details><summary><h4>Context used (11)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=a0874d39-0a5e-4338-a068-b193d0ba4c8c))
- Context used - bundled-skills/dbos-python/CLAUDE.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=45ba760d-ca1b-4d3d-8f3d-a91df29d5767))
- Context used - bundled-skills/dbos-golang/CLAUDE.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=05943a03-9ff5-4daf-aa6b-cd894f002422))
- Context used - bundled-skills/postgres-best-practices/AGENTS.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=4c5d4261-e46d-48b5-80e5-6b0d4b6e61c8))
- Context used - bundled-skills/loki-mode/references/agents.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=a44989fd-f4af-41a8-bcaf-b64d883e3d1a))
- Context used - bundled-skills/loki-mode/CLAUDE.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=a2c2ecb4-ac84-4ab3-ac63-01878b6da9d6))
- Context used - bundled-skills/react-best-practices/AGENTS.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=ef9aedc5-5efe-456e-bdd0-8b86d303e731))
- Context used - bundled-skills/dbos-python/AGENTS.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=48041e57-200a-4145-bb4e-c73792818554))
- Context used - bundled-skills/dbos-golang/AGENTS.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=53f72eed-22af-4919-9be0-2e8db8a4fe32))
- Context used - bundled-skills/dbos-typescript/CLAUDE.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=698f4998-ef97-4bc5-99fa-6b0d66a15513))
- Context used - bundled-skills/dbos-typescript/AGENTS.md ([source](https://app.greptile.com/davide-ladisa/github/FrancoStino/opencode-skills-collection/-/custom-context?memory=0578b0dd-1289-40e4-a137-90ab43591500))
</details>

<!-- /greptile_comment -->